### PR TITLE
Fix data between pcs

### DIFF
--- a/examples/tinyPDC.py
+++ b/examples/tinyPDC.py
@@ -6,27 +6,36 @@ tinyPDC will connect to pmu_ip:pmu_port and send request
 for header message, configuration and eventually
 to start sending measurements.
 """
+import socket
 
 
 if __name__ == "__main__":
 
-    pdc = Pdc(pdc_id=7, pmu_ip="127.0.0.1", pmu_port=1410)
+    ip = socket.gethostbyname(socket.gethostname())
+    ip = "10.219.106.36"
+    pdc = Pdc(pdc_id=7, pmu_ip=ip, pmu_port=2223)
     pdc.logger.setLevel("DEBUG")
 
     pdc.run()  # Connect to PMU
 
-    header = pdc.get_header()  # Get header message from PMU
     config = pdc.get_config()  # Get configuration from PMU
 
     pdc.start()  # Request to start sending measurements
-
-    while True:
-
+   
+    i = 0
+    data_array = []
+    while i < 3:
         data = pdc.get()  # Keep receiving data
 
         if type(data) == DataFrame:
-            print(data.get_measurements())
+            data_array.append(data.get_measurements())
+        else:
+            if not data:
+                pdc.quit()  # Close connection
+                break
 
-        if not data:
-            pdc.quit()  # Close connection
-            break
+            if len(data)>0:
+                for meas in data: 
+                    data_array.append(meas.get_measurements())
+
+        i += 1

--- a/examples/tinyPDC.py
+++ b/examples/tinyPDC.py
@@ -12,12 +12,13 @@ import socket
 if __name__ == "__main__":
 
     ip = socket.gethostbyname(socket.gethostname())
-    ip = "10.219.106.36"
-    pdc = Pdc(pdc_id=7, pmu_ip=ip, pmu_port=2223)
+    ip = "192.168.10.107"
+    pdc = Pdc(pdc_id=1111, pmu_ip=ip, pmu_port=2223)
     pdc.logger.setLevel("DEBUG")
 
     pdc.run()  # Connect to PMU
-
+    
+    pdc.stop()
     config = pdc.get_config()  # Get configuration from PMU
 
     pdc.start()  # Request to start sending measurements

--- a/synchrophasor/frame.py
+++ b/synchrophasor/frame.py
@@ -1858,7 +1858,6 @@ class DataFrame(CommonFrame):
         self.cfg = cfg
         self.set_stat(stat)
         self.set_phasors(phasors)
-        print("Freq is " +str(freq))
         self.set_freq(freq)
         self.set_dfreq(dfreq)
         self.set_analog(analog)
@@ -2421,7 +2420,6 @@ class DataFrame(CommonFrame):
 
             if not CommonFrame._check_crc(byte_data):
                 raise FrameError("CRC failed. Configuration frame not valid.")
-            print(cfg)
             num_pmu = cfg.get_num_pmu()
             data_format = cfg.get_data_format()
             phasor_num = cfg.get_phasor_num()

--- a/synchrophasor/frame.py
+++ b/synchrophasor/frame.py
@@ -13,7 +13,7 @@ Data Transfer for Power Systems.
 
 """
 
-import collections
+import collections.abc
 from abc import ABCMeta, abstractmethod
 from struct import pack, unpack
 from time import time
@@ -232,7 +232,7 @@ class CommonFrame(metaclass=ABCMeta):
             self.set_soc(int(t))  # Get current timestamp
 
         if frasec is not None:
-            if isinstance(frasec, collections.Sequence):
+            if isinstance(frasec, collections.abc.Sequence):
                 self.set_frasec(*frasec)
             else:
                 self.set_frasec(frasec)  # Just set fraction of second and use default values for other arguments.
@@ -1858,6 +1858,7 @@ class DataFrame(CommonFrame):
         self.cfg = cfg
         self.set_stat(stat)
         self.set_phasors(phasors)
+        print("Freq is " +str(freq))
         self.set_freq(freq)
         self.set_dfreq(dfreq)
         self.set_analog(analog)
@@ -1917,7 +1918,7 @@ class DataFrame(CommonFrame):
         if isinstance(trigger_reason, str):
             trigger_reason = DataFrame.TRIGGER_REASON[trigger_reason]
 
-        stat = measurement_status << 2
+        stat = measurement_status << 1
         if not sync:
             stat |= 1
 
@@ -1952,7 +1953,7 @@ class DataFrame(CommonFrame):
     @staticmethod
     def _int2stat(stat):
 
-        measurement_status = DataFrame.MEASUREMENT_STATUS_WORDS[stat >> 15]
+        measurement_status = DataFrame.MEASUREMENT_STATUS_WORDS[stat >> 14]
         sync = bool(stat & 0x2000)
 
         if stat & 0x1000:
@@ -1964,8 +1965,8 @@ class DataFrame(CommonFrame):
         cfg_change = bool(stat & 0x400)
         modified = bool(stat & 0x200)
 
-        time_quality = DataFrame.TIME_QUALITY_WORDS[stat & 0x1c0]
-        unlocked = DataFrame.UNLOCKED_TIME_WORDS[stat & 0x30]
+        time_quality = DataFrame.TIME_QUALITY_WORDS[stat & 0x1c0>>6]
+        unlocked = DataFrame.UNLOCKED_TIME_WORDS[stat & 0x30>>4]
         trigger_reason = DataFrame.TRIGGER_REASON_WORDS[stat & 0xf]
 
         return measurement_status, sync, sorting, trigger, cfg_change, modified, time_quality, unlocked, trigger_reason
@@ -2141,7 +2142,8 @@ class DataFrame(CommonFrame):
             data_format = DataFrame._int2format(data_format)
 
         if data_format[3]:  # FREQ/DFREQ floating point
-            if not -32.767 <= freq <= 32.767:
+            #if not -32.767 <= freq <= 32.767:
+            if not -100 <= freq <= 100:
                 raise ValueError("FREQ must be in range -32.767 <= FREQ <= 32.767.")
 
             freq = unpack("!I", pack("!f", float(freq)))[0]
@@ -2419,7 +2421,7 @@ class DataFrame(CommonFrame):
 
             if not CommonFrame._check_crc(byte_data):
                 raise FrameError("CRC failed. Configuration frame not valid.")
-
+            print(cfg)
             num_pmu = cfg.get_num_pmu()
             data_format = cfg.get_data_format()
             phasor_num = cfg.get_phasor_num()

--- a/synchrophasor/pdc.py
+++ b/synchrophasor/pdc.py
@@ -117,7 +117,6 @@ class Pdc(object):
         """
 
         received_data = b""
-        received_message = None
 
         """
         Keep receiving until SYNC + FRAMESIZE is received, 4 bytes in total.
@@ -138,19 +137,44 @@ class Pdc(object):
                 break
             received_data += message_chunk
             bytes_received += len(message_chunk)
+        
+        # Check if we received a whole multiplicum of data
+        if len(received_data)%total_frame_size==0:
+            print("Received data length " + str(len(received_data)))
+            print("Tota frame size " + str(total_frame_size))
+            n_messages = int(len(received_data)/total_frame_size)
+            if n_messages == 1:
+                return self.decode(received_data)
+            else:
+                i = 0
+                messages = []
+                while i < n_messages:
+                    messages.append(
+                        self.decode(
+                            received_data[
+                                i*total_frame_size:total_frame_size*(1+i)]))
+                    i += 1
 
-        # If complete message is received try to decode it
-        if len(received_data) == total_frame_size:
-            try:
-                received_message = CommonFrame.convert2frame(received_data, self.pmu_cfg2)  # Try to decode received data
-                self.logger.debug("[%d] - Received %s from PMU (%s:%d)", self.pdc_id, type(received_message).__name__,
-                                  self.pmu_ip, self.pmu_port)
-            except FrameError:
-                self.logger.warning("[%d] - Received unknown message from PMU (%s:%d)",
-                                    self.pdc_id, self.pmu_ip, self.pmu_port)
+                return messages
+    
+    def decode(self, received_data):
+        """
+        Decode a chunck of received_data
+        """
+        received_message = None
+        # Try to decode received data
+        try:
+            received_message = CommonFrame.convert2frame(received_data,
+                                                         self.pmu_cfg2)
+            self.logger.debug("[%d] - Received %s from PMU (%s:%d)",
+                              self.pdc_id, type(received_message).__name__,
+                              self.pmu_ip, self.pmu_port)
+        except FrameError:
+            self.logger.warning(
+                "[%d] - Received unknown message from PMU (%s:%d)",
+                self.pdc_id, self.pmu_ip, self.pmu_port)
 
         return received_message
-
 
     def quit(self):
         """

--- a/synchrophasor/pdc.py
+++ b/synchrophasor/pdc.py
@@ -137,9 +137,6 @@ class Pdc(object):
             received_data += message_chunk
             bytes_received += len(message_chunk)
         
-        print("Received data length " + str(len(received_data)))
-        print("Total frame size " + str(total_frame_size))
-        
         # Check if we received whole packages of data
         if len(received_data)%total_frame_size==0:
             n_messages = int(len(received_data)/total_frame_size)
@@ -163,16 +160,16 @@ class Pdc(object):
         """
         received_message = None
         # Try to decode received data
-        #try:
-        received_message = CommonFrame.convert2frame(received_data,
-                                                     self.pmu_cfg2)
-        self.logger.debug("[%d] - Received %s from PMU (%s:%d)",
-                          self.pdc_id, type(received_message).__name__,
-                          self.pmu_ip, self.pmu_port)
-        #except FrameError:
-        #    self.logger.warning(
-        #        "[%d] - Received unknown message from PMU (%s:%d)",
-        #        self.pdc_id, self.pmu_ip, self.pmu_port)
+        try:
+            received_message = CommonFrame.convert2frame(received_data,
+                                                         self.pmu_cfg2)
+            self.logger.debug("[%d] - Received %s from PMU (%s:%d)",
+                              self.pdc_id, type(received_message).__name__,
+                              self.pmu_ip, self.pmu_port)
+        except FrameError:
+            self.logger.warning(
+                "[%d] - Received unknown message from PMU (%s:%d)",
+                self.pdc_id, self.pmu_ip, self.pmu_port)
 
         return received_message
 

--- a/synchrophasor/pdc.py
+++ b/synchrophasor/pdc.py
@@ -138,7 +138,7 @@ class Pdc(object):
             received_data += message_chunk
             bytes_received += len(message_chunk)
         
-        # Check if we received a whole multiplicum of data
+        # Check if we received whole packages of data
         if len(received_data)%total_frame_size==0:
             print("Received data length " + str(len(received_data)))
             print("Tota frame size " + str(total_frame_size))

--- a/synchrophasor/pdc.py
+++ b/synchrophasor/pdc.py
@@ -3,7 +3,6 @@ import socket
 from sys import stdout
 from synchrophasor.frame import *
 
-
 __author__ = "Stevan Sandi"
 __copyright__ = "Copyright (c) 2016, Tomo Popovic, Stevan Sandi, Bozo Krstajic"
 __credits__ = []
@@ -138,10 +137,11 @@ class Pdc(object):
             received_data += message_chunk
             bytes_received += len(message_chunk)
         
+        print("Received data length " + str(len(received_data)))
+        print("Total frame size " + str(total_frame_size))
+        
         # Check if we received whole packages of data
         if len(received_data)%total_frame_size==0:
-            print("Received data length " + str(len(received_data)))
-            print("Tota frame size " + str(total_frame_size))
             n_messages = int(len(received_data)/total_frame_size)
             if n_messages == 1:
                 return self.decode(received_data)
@@ -163,16 +163,16 @@ class Pdc(object):
         """
         received_message = None
         # Try to decode received data
-        try:
-            received_message = CommonFrame.convert2frame(received_data,
-                                                         self.pmu_cfg2)
-            self.logger.debug("[%d] - Received %s from PMU (%s:%d)",
-                              self.pdc_id, type(received_message).__name__,
-                              self.pmu_ip, self.pmu_port)
-        except FrameError:
-            self.logger.warning(
-                "[%d] - Received unknown message from PMU (%s:%d)",
-                self.pdc_id, self.pmu_ip, self.pmu_port)
+        #try:
+        received_message = CommonFrame.convert2frame(received_data,
+                                                     self.pmu_cfg2)
+        self.logger.debug("[%d] - Received %s from PMU (%s:%d)",
+                          self.pdc_id, type(received_message).__name__,
+                          self.pmu_ip, self.pmu_port)
+        #except FrameError:
+        #    self.logger.warning(
+        #        "[%d] - Received unknown message from PMU (%s:%d)",
+        #        self.pdc_id, self.pmu_ip, self.pmu_port)
 
         return received_message
 


### PR DESCRIPTION
In some cases when transferring data between two pcs the pdc recives more than one package of data in one iteration. In these cases the code crashes. I made some changes that detects when this happens and then splits the data packages in to packages that can be decoded. It may be possible to solve this problem by increasing the priority of the process running the pdc in the operating system settings too.